### PR TITLE
Fix Repo name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ In our dev life, we have some code snippets that we frequently use. The goal of 
 * Fork the repository (Click the Fork button in the top right of this page, click your Profile Image)
 * Clone the forked repository to your local machine.
 ```markdown
-git clone https://github.com/your-user-name/django-mate.git
+git clone https://github.com/your-user-name/dev-mates.git
 ```
 * change the present working directory
 ```markdown
-cd django-mate
+cd dev-mates
 ```
 * Add/Create your code snippet to the specific folder as described in what you can contribute section.
 * Make a new branch


### PR DESCRIPTION
Recently the Repo name was changed to `dev-mates` from `dajngo-mate` along with the readme file. But there were a little bug in readme that somewhere is was still named as `django-mate` and I fixed that in this PR. 